### PR TITLE
1.2alpha1

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -32,6 +32,7 @@ setuptools.setup(
     packages=[i.__name__],
     python_requires='>=3.8',
     install_requires=[x.decode() for x in requires_file if x],
+    extras_require={'pyyaml': ['PyYAML>=6.0,<7.0'],},
     classifiers=[
         'Development Status :: 4 - Beta',
         'Intended Audience :: Developers',


### PR DESCRIPTION
1. Added support for read and write operations for specific file types (ini, csv, json, yaml).
2. To enhance applicability, indirectly referenced the `Content.contains` method in the `File` class.
3. Adjusted the implementation of multiple indirectly referenced methods in the `File` class.
4. Added the `Path.__len__` method to quickly get the length of the path string.
5. Exposed the `Content.md5` method for use.
6. To enhance applicability, added two deprecated methods in the `File` class: `create` and `creates`.
---
1. 增加了对特定文件类型（ini, csv, json, yaml）的读写操作支持。
2. 为了提高适用性，在 `File` 类中间接引用了 `Content.contains` 方法。
3. 调整了 `File` 类中的多个间接引用方法的实现。
4. 新增了 `Path.__len__` 方法，以便快速获取路径字符串的长度。
5. 暴露了 `Content.md5` 方法以供使用。
6. 为了提高适用性，在 `File` 类中增加了两个标记为弃用的方法： `create` 和 `creates`。
